### PR TITLE
Pass config to doAction() for future use

### DIFF
--- a/src/gdsync.nim
+++ b/src/gdsync.nim
@@ -19,7 +19,7 @@ proc main*(argv: seq[string] = nil): int =
   echo argv
   return 1
 
-proc doAction(options: Options) =
+proc doAction(options: Options, config: Config) =
   case options.action.typ
   of actionNil:
     if options.showHelp:
@@ -40,7 +40,7 @@ when isMainModule:
 
   try:
     let config = loadConfig()
-    parseCmdLine().doAction()
+    parseCmdLine().doAction(config)
     quit(0)
   except:
     echo getCurrentExceptionMsg()


### PR DESCRIPTION
Future actions may need settings from the config, rather than load it into global space, pass it to the function for use.