### PR TITLE
FIX #15: Use of const values hard codes path into binary at build time

### DIFF
--- a/src/gdsyncpkg/config.nim
+++ b/src/gdsyncpkg/config.nim
@@ -2,9 +2,9 @@ import os
 import tables
 import json
 
-const config_dir = joinPath(getConfigDir(), "gdsync")
 const config_file_name = "config.json"
-const config_file_path = joinPath(config_dir, config_file_name)
+let config_dir = joinPath(getConfigDir(), "gdsync")
+let config_file_path = joinPath(config_dir, config_file_name)
 
 type Config* = object
   PidFile*: string


### PR DESCRIPTION
Fixed #15 
Make config variables none constant so they aren't generated at build.